### PR TITLE
Multi cluster

### DIFF
--- a/charts/console/templates/db.yaml
+++ b/charts/console/templates/db.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.cluster.role "leader" }}
 # Postgres Database
 apiVersion: apps/v1
 kind: StatefulSet
@@ -67,3 +68,4 @@ spec:
   selector:
     app.kubernetes.io/component: db
     {{- include "console.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.cluster.role "leader" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -79,57 +80,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ include "console.fullname" . }}-reconciler
-  labels:
-    {{- include "console.labels" . | nindent 4 }}
-    app.kubernetes.io/component: reconciler
-spec:
-  replicas: {{ .Values.cluster.reconciler.replicaCount }}
-  selector:
-    matchLabels:
-      {{- include "console.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: reconciler
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/component: reconciler
-        {{- include "console.labels" . | nindent 8 }}
-    spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      serviceAccountName: {{ include "console.serviceAccountName" . }}
-      containers:
-        - name: {{ .Chart.Name }}-reconciler
-          image: "{{ .Values.cluster.reconciler.image.repository }}:{{ .Values.cluster.reconciler.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.cluster.reconciler.image.pullPolicy }}
-          {{- with .Values.cluster.reconciler.ports }}
-          ports:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          env:
-            {{- include "console.zeusReconcilerEnv" . | nindent 12 }}
-          {{- with .Values.cluster.reconciler.livenessProbe }}
-          livenessProbe:
-            httpGet:
-              path: {{ .httpGet.path | quote }}
-              port: {{ .httpGet.port }}
-          {{- end }}
-          {{- with .Values.cluster.reconciler.readinessProbe }}
-          readinessProbe:
-            httpGet:
-              path: {{ .httpGet.path | quote }}
-              port: {{ .httpGet.port }}
-          {{- end }}
-          {{- with .Values.cluster.reconciler.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -487,3 +437,55 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end}}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "console.fullname" . }}-reconciler
+  labels:
+    {{- include "console.labels" . | nindent 4 }}
+    app.kubernetes.io/component: reconciler
+spec:
+  replicas: {{ .Values.cluster.reconciler.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "console.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: reconciler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: reconciler
+        {{- include "console.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "console.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}-reconciler
+          image: "{{ .Values.cluster.reconciler.image.repository }}:{{ .Values.cluster.reconciler.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.cluster.reconciler.image.pullPolicy }}
+          {{- with .Values.cluster.reconciler.ports }}
+          ports:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "console.zeusReconcilerEnv" . | nindent 12 }}
+          {{- with .Values.cluster.reconciler.livenessProbe }}
+          livenessProbe:
+            httpGet:
+              path: {{ .httpGet.path | quote }}
+              port: {{ .httpGet.port }}
+          {{- end }}
+          {{- with .Values.cluster.reconciler.readinessProbe }}
+          readinessProbe:
+            httpGet:
+              path: {{ .httpGet.path | quote }}
+              port: {{ .httpGet.port }}
+          {{- end }}
+          {{- with .Values.cluster.reconciler.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -83,6 +83,57 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: {{ include "console.fullname" . }}-reconciler
+  labels:
+    {{- include "console.labels" . | nindent 4 }}
+    app.kubernetes.io/component: reconciler
+spec:
+  replicas: {{ .Values.cluster.reconciler.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "console.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: reconciler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: reconciler
+        {{- include "console.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "console.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}-reconciler
+          image: "{{ .Values.cluster.reconciler.image.repository }}:{{ .Values.cluster.reconciler.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.cluster.reconciler.image.pullPolicy }}
+          {{- with .Values.cluster.reconciler.ports }}
+          ports:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "console.zeusReconcilerEnv" . | nindent 12 }}
+          {{- with .Values.cluster.reconciler.livenessProbe }}
+          livenessProbe:
+            httpGet:
+              path: {{ .httpGet.path | quote }}
+              port: {{ .httpGet.port }}
+          {{- end }}
+          {{- with .Values.cluster.reconciler.readinessProbe }}
+          readinessProbe:
+            httpGet:
+              path: {{ .httpGet.path | quote }}
+              port: {{ .httpGet.port }}
+          {{- end }}
+          {{- with .Values.cluster.reconciler.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: {{ include "console.fullname" . }}-frontend
   labels:
     {{- include "console.labels" . | nindent 4 }}

--- a/charts/console/templates/ingress.yaml
+++ b/charts/console/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tailscale.enabled -}}
+{{- if and (eq .Values.cluster.role "leader") .Values.tailscale.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -12,5 +12,5 @@ spec:
   ingressClassName: tailscale
   tls:
     - hosts:
-      -  {{ include "console.tailscale" $ }}
+      - {{ include "console.tailscale" $ }}
 {{- end }}

--- a/charts/console/templates/secret.yaml
+++ b/charts/console/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.cluster.role "leader" }}
 {{ if .Values.secret.generate }}
 apiVersion: v1
 kind: Secret
@@ -8,3 +9,4 @@ stringData:
   dbUser: "postgres"
   dbPassword: "postgres"
 {{ end }}
+{{- end }}

--- a/charts/console/templates/service.yaml
+++ b/charts/console/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.cluster.role "leader" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -100,4 +101,5 @@ spec:
   selector:
     app.kubernetes.io/component: debug
     {{- include "console.selectorLabels" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -39,6 +39,44 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+cluster:
+  # “leader” = bring up backend+frontend+db+reverseproxy+reconciler+inferenceStack
+  # “follower” = only reconciler+inferenceStack
+  role: leader
+  # The name of the cluster to use. This is used to identify the cluster in the console. Must be unique across all clusters.
+  # Will default to the name of the release for leader clusters, if not set. Must be set for follower clusters.
+  name: ""  
+
+  reconciler:
+    replicaCount: 1
+
+    image:
+      repository: tytn/zeus-reconciler
+      # Overrides the image tag whose default is the chart appVersion.
+      tag: ""
+      pullPolicy: IfNotPresent
+
+    # If this is the leader cluster, the url will be generated automatically. If this is a follower, it must be configured
+    centralBaseURL: ""
+
+    env: []
+
+    # This doesnt need to be exposed - it is only used by k8s to check the health of the reconciler
+    ports:
+    - name: health
+      containerPort: 8080
+      protocol: TCP
+
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: health
+    readinessProbe:
+      httpGet:
+        path: /healthz
+        port: health
+
+
 # This section is for setting up the Inference Stack Custom Resource that is deployed and managed by the console. The crdVersion is
 # the version of the Custom Resource Definition that is being used. The operatorVersion is the version of the operator that is being
 # used to manage the Custom Resource. See the ../../CHANGELOG.md for more information on the versions.


### PR DESCRIPTION
Adds the reconciler component - the backend server is the central brain, and wrapper of the db (the desired state), while the reconcilers are the probes and executors. They are responsible for all K8s API interaction: applying patches to the InferenceStack, and gathering Node information.

This also introduces a leader/follower abstraction into the helm chart. Running a console as 'leader' activates the frontend, backend, db, auth, reverse proxy, a reconciler for the cluster, and an inference stack operator. Running as a 'follower' activates just a reconciler and inference stack operator. ZEUS_CENTRAL_BASE_URL will be derived automatically for leader setups, and need to be set for followers.

NOTE: this is for dev and test modes currently - there is currently no auth or protections for the reconciler -> central communication 