### PR TITLE
fix: make dpp image land on gpu

### DIFF
--- a/charts/rag/Chart.yaml
+++ b/charts/rag/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.2
+version: 1.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rag/templates/deployment.yaml
+++ b/charts/rag/templates/deployment.yaml
@@ -146,6 +146,18 @@ spec:
               mountPath: /code/config.yaml
               subPath: config.yaml
               readOnly: true
+      {{- with .Values.dpp.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dpp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dpp.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/charts/rag/values.yaml
+++ b/charts/rag/values.yaml
@@ -211,3 +211,50 @@ dpp:
   resources: {}
   livenessProbe: {}
   readinessProbe: {}
+  tolerations:
+    # GKE (Google Kubernetes Engine)
+    - key: nvidia.com/gpu
+      operator: Equal
+      value: present
+      effect: NoSchedule
+    # EKS (Amazon Elastic Kubernetes Service) - if configured
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    # AKS (Azure Kubernetes Service)
+    - key: sku
+      operator: Equal
+      value: gpu
+      effect: NoSchedule
+    # Generic/Custom Kubernetes
+    - key: dedicated
+      operator: Equal
+      value: gpu
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        # GKE (Google Kubernetes Engine)
+        - matchExpressions:
+          - key: nvidia.com/gpu.present
+            operator: In
+            values: ["true"]
+        # EKS (Amazon Elastic Kubernetes Service)
+        - matchExpressions:
+          - key: k8s.amazonaws.com/accelerator
+            operator: Exists
+        # AKS (Azure Kubernetes Service)
+        - matchExpressions:
+          - key: accelerator
+            operator: In
+            values: ["nvidia", "gpu"]
+        # Generic Kubernetes (common custom label)
+        - matchExpressions:
+          - key: node.kubernetes.io/gpu
+            operator: Exists
+        # On-premise/Custom Kubernetes
+        - matchExpressions:
+          - key: hardware-type
+            operator: In
+            values: ["gpu", "nvidia-gpu"]


### PR DESCRIPTION
## Context
The takeoff-pro image is currently tagged as `rc37-cpu` but due to issues with the image, it needs to run on GPU nodes. This configuration ensures the pod will only be scheduled on GPU nodes regardless of the cloud provider.

## Changes Made

### 1. Added GPU Node Affinity (`helm-charts/charts/rag/values.yaml`)
- Added flexible node affinity rules that match GPU nodes across different cloud providers:
  - GKE: `nvidia.com/gpu.present: "true"`
  - EKS: `k8s.amazonaws.com/accelerator`
  - AKS: `accelerator: nvidia/gpu`
  - Generic: `node.kubernetes.io/gpu` and `hardware-type: gpu/nvidia-gpu`

### 2. Added GPU Tolerations (`helm-charts/charts/rag/values.yaml`)
- Added tolerations for common GPU node taints across cloud providers
- Ensures pods can be scheduled on tainted GPU nodes

### 3. Updated Deployment Template (`helm-charts/charts/rag/templates/deployment.yaml`)
- Added support for `nodeSelector`, `tolerations`, and `affinity` configurations
- Template now properly renders these scheduling constraints for the DPP pod

