### PR TITLE
Add metrics into onwards

### DIFF
--- a/charts/onwards/Chart.yaml
+++ b/charts/onwards/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: onwards
 description: Onwards Helm Chart
 type: application
-version: 0.4.0
-appVersion: "v0.2.0"
+version: 0.5.0
+appVersion: "v0.3.0"

--- a/charts/onwards/templates/deployment.yaml
+++ b/charts/onwards/templates/deployment.yaml
@@ -44,6 +44,11 @@ spec:
           {{- end }}
           {{- with .Values.ports }}
           ports:
+            {{- if and .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            {{- end }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.livenessProbe }}
@@ -64,6 +69,15 @@ spec:
           {{- end }}
           args:
             - "-f=/app/config/config.json"
+            {{- if .Values.metrics.enabled }}
+            - "--metrics"
+            {{- with .Values.metrics.port }}
+            - "--metrics-port={{ . }}"
+            {{- end }}
+            {{- with .Values.metrics.prefix }}
+            - "--metrics-prefix={{ . }}"
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /app/config

--- a/charts/onwards/templates/deployment.yaml
+++ b/charts/onwards/templates/deployment.yaml
@@ -44,9 +44,9 @@ spec:
           {{- end }}
           {{- with .Values.ports }}
           ports:
-            {{- if and .Values.metrics.enabled }}
+            {{- if and $.Values.metrics.enabled }}
             - name: metrics
-              containerPort: {{ .Values.metrics.port }}
+              containerPort: {{ $.Values.metrics.port }}
               protocol: TCP
             {{- end }}
             {{- toYaml . | nindent 12 }}

--- a/charts/onwards/templates/service.yaml
+++ b/charts/onwards/templates/service.yaml
@@ -11,6 +11,12 @@ spec:
     {{- include "onwards.selectorLabels" . | nindent 4 }}
   ports:
     {{- toYaml .Values.service.ports | nindent 4 }}
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: {{ .Values.metrics.port }}
+      protocol: TCP
+    {{- end }}
   type: {{ .Values.service.type }}
 {{- end }}
 {{- $ns := .Release.Namespace }}

--- a/charts/onwards/templates/serviceMonitor.yaml
+++ b/charts/onwards/templates/serviceMonitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "onwards.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onwards.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "onwards.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+{{- end }}

--- a/charts/onwards/values.yaml
+++ b/charts/onwards/values.yaml
@@ -74,7 +74,8 @@ service:
   enabled: true
   type: ClusterIP
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 80
       targetPort: 3000
 

--- a/charts/onwards/values.yaml
+++ b/charts/onwards/values.yaml
@@ -102,5 +102,5 @@ ingress:
 # Metrics configuration - uses prometheus so relies on that already being installed into the cluster as will try to create a ServiceMonitor resource.
 metrics:
   enabled: false
-  port: 8080
+  port: 9090
   prefix: "onwards"

--- a/charts/onwards/values.yaml
+++ b/charts/onwards/values.yaml
@@ -98,3 +98,9 @@ ingress:
   #               name: onwards
   #               port:
   #                 number: 80
+
+# Metrics configuration - uses prometheus so relies on that already being installed into the cluster as will try to create a ServiceMonitor resource.
+metrics:
+  enabled: false
+  port: 8080
+  prefix: "onwards"


### PR DESCRIPTION
Add option to turn on prometheus metrics for onwards chart. Set to false by default for backwards compatibility. Following: https://github.com/doublewordai/onwards/pull/9.